### PR TITLE
Add Bootstrap User Support to Jenkins

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,12 @@ See [NATIVE_TYPES_AND_PROVIDERS.md](NATIVE_TYPES_AND_PROVIDERS.md)
 ## Remoting Free CLI
 
 Jenkins refactored the CLI in 2.54 and 2.46.2 in response to several security
-incidents (See [JENKINS-41745](https://issues.jenkins-ci.org/browse/JENKINS-41745). This module has been adjusted to support the new CLI. However you
+incidents (See [JENKINS-41745](https://issues.jenkins-ci.org/browse/JENKINS-41745)). This module has been adjusted to support the new CLI. However you
 need to tell the module if the new remoting free cli is in place. Please set
-```$::jenkins::cli_remoting_free``` to true for latest Jenkins servers.
+```$::jenkins::cli_remoting_free``` to ```true``` for latest Jenkins servers.
 
-Note: This is not the default to support backward compatibility. This may become
-a default once this module is released in a new version.
+Note: Setting this to ```true``` is not the default, to support backward compatibility. 
+This may become a default once this module is released in a new version.
 
 Also note that the module tries to do heuristics for this setting if not specified.
 You can always set this parameter to enforce usage of old or new CLI interface.
@@ -55,17 +55,119 @@ Heuristics:
 
 ## Username and Password Auth
 
-The new CLI also supports proper authentication with username and password. This
-has not been supported in this module for a long time, but is a requirement for
+The new CLI also supports proper authentication with username/password or password_file.
+This has not been supported in this module for a long time, but is a requirement for
 supporting AD and OpenID authentications (there is no ssh key there). You can now
-also supply ```$::jenkins::cli_username``` and ```$::jenkins::cli_password``` to
-use username / password based authentication. Then the puppet automation user can
-also reside in A.D
+also supply ```$::jenkins::cli_username``` and ```$::jenkins::cli_password``` or 
+```$::jenkins::cli_password_file``` to use username / password based authentication. 
+Then the puppet automation user can also reside in ActiveDirectory.
 
 Note: latest jenkins (2.54++ and 2.46.2++) require a ssh username, so you must also
 provide ```$::jenkins::cli_username``` for ssh. If you specify both username/password
 and ssh key file, SSH authentication is preferred.
 
+If you specify a ```$::jenkins::cli_password_file```, the file must be created by you. It
+is recommended to use a password_file, as username and password are passed through with
+-auth USERNAME:PASSWORD, which is visible in the process listing. With cli_password_file
+the password is not visible.
+
+# Jenkins 2.0 bootstrapping
+
+Jenkins 2.0 comes with "secure by default" settings. This means if you
+deploy a jenkins server, it is automatically set to "full_control" authz
+strategy, which in turn means, this puppet module can not use the CLI 
+to configure Jenkins, as there are no credentials yet. 
+
+To support "provisioning on first run" with this module, we use the 
+init.groovy.d approach described in [Configuring Jenkins upon start up](https://wiki.jenkins-ci.org/display/JENKINS/Configuring+Jenkins+upon+start+up)
+to setup an initial bootstrapping user that can then be used as automation user.
+
+**Note:** If you use SSH credentials, we do **not generate** or manage the ssh private 
+key file for you, this module adds the SSH public key to the jenkins user, however the
+ssh key file (```$::jenkins::cli_ssh_keyfile```) must be created by you or your
+puppet code prior to calling the jenkins class.
+
+## Usage examples: 
+
+### Jenkins prior to 2.54 or 2.46.2 (LTS) with SSH Key:
+
+Note: you must manage / create /root/ssh_for_jenkins.
+
+```puppet
+class { jenkins:
+  lts                => true,
+  cli_ssh_keyfile    => '/root/ssh_for_jenkins',
+  bootstrapuser_hash => {
+    'puppet' => {
+      ensure => present,
+      email => 'user@host.com',
+      full_name => 'Puppet bootstrapping user, do not remove',
+      public_key => 'ssh-rsa AAAA.... puppet automation user',
+    }
+  }
+}
+
+class { jenkins::security:
+  security_model => full_control,
+}
+
+```
+
+### Jenkins >= 2.54 and 2.46.2 (LTS) with SSH Key: 
+
+Note: you must manage / create /root/ssh_for_jenkins.
+
+```puppet
+class { jenkins:
+  lts               => true,
+  cli_remoting_free => true,
+  cli_ssh_keyfile   => '/root/ssh_for_jenkins',
+  cli_username      => 'puppet',
+  jenkins_sshd_port => 0,
+  bootstrapuser_hash => {
+    'puppet' => {
+      ensure     => present,
+      email      => 'user@host.com',
+      full_name  => 'Puppet bootstrapping user, do not remove',
+      public_key => 'ssh-rsa AAAA.... puppet automation user',
+    }
+  }
+}
+
+class { jenkins::security:
+  security_model => full_control,
+}
+```
+
+### Jenkins prior to 2.54 or 2.46.2 (LTS) with username / password:
+
+Note: This is not supported, due to serveral bugs (See [JENKINS-12543](https://issues.jenkins-ci.org/browse/JENKINS-12543))
+
+### Jenkins >= 2.54 and 2.46.2 (LTS) with username / password: 
+
+```puppet
+class { jenkins:
+  lts               => true,
+  cli_remoting_free => true,
+  cli_username      => 'puppet',
+  cli_password      => 'ThisIsMyPassword',
+  bootstrapuser_hash => {
+    'puppet' => {
+      ensure     => present,
+      email      => 'user@host.com',
+      password   => 'ThisIsMyPassword',
+      full_name  => 'Puppet bootstrapping user, do not remove',
+    }
+  }
+}
+
+class { jenkins::security:
+  security_model => full_control,
+}
+
+```
+
+Note: Bootstrapping support can be disabled by setting ```$::jenkins::manage_bootstrapping``` to false.
 
 # Using puppet-jenkins
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -21,6 +21,58 @@ class jenkins::config {
     mode   => '0755',
   }
 
+  # Lets manage the bootstrap directory
+  if $::jenkins::manage_bootstrapping {
+
+    # Some more validation, as empty var leads to purge /init.groovy.d
+    if empty($::jenkins::jenkins_home) {
+      fail("ERROR: Need a jenkins home dir if \$::jenkins::manage_bootstrapping is enabled")
+    }
+    validate_absolute_path($::jenkins::jenkins_home)
+
+    # Do we and only we manage the dir ? 
+    if $::jenkins::purge_bootstrapping {
+      $_purge_bootstrapping_dir = true
+      $_recurse_bootstrapping_dir = true
+    } else {
+      $_purge_bootstrapping_dir = false
+      $_recurse_bootstrapping_dir = false
+    }
+
+    file { "${::jenkins::jenkins_home}/init.groovy.d":
+      ensure  => directory,
+      owner   => $::jenkins::user,
+      group   => $::jenkins::group,
+      mode    => '0750',
+      tag     => 'jenkins_groovy_init_script',
+      purge   => $_purge_bootstrapping_dir,
+      recurse => $_recurse_bootstrapping_dir,
+    }
+
+    # Restart jenkins if content changed
+    File <| tag == 'jenkins_groovy_init_script' |> ~> Service <| title == 'jenkins' |>
+
+  }
+
+  $_jenkins_sshd_port = $::jenkins::jenkins_sshd_port
+
+  if $::jenkins::manage_bootstrapping and $::jenkins::jenkins_sshd_port {
+    $_sshd_groovy_ensure = present
+  } else {
+    $_sshd_groovy_ensure = absent
+  }
+
+  file { "${::jenkins::jenkins_home}/init.groovy.d/puppet.sshd.groovy":
+    ensure    => $_sshd_groovy_ensure,
+    owner     => $::jenkins::user,
+    group     => $::jenkins::group,
+    mode      => '0644',
+    tag       => 'jenkins_groovy_init_script',
+    show_diff => true,
+    content   => template('jenkins/home/jenkins/init.groovy.d/puppet.sshd.groovy.erb'),
+  }
+
+
   # ensure_resource is used to try to maintain backwards compatiblity with
   # manifests that were able to external declare resources due to the
   # old conditional behavior of jenkins::plugin

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -17,6 +17,10 @@ class jenkins::params {
   $cli_try_sleep         = 10
   $package_cache_dir     = '/var/cache/jenkins_pkgs'
   $package_name          = 'jenkins'
+  $manage_bootstrapping  = true
+  $purge_bootstrapping   = false
+  $jenkins_sshd_port     = undef
+
 
   $manage_datadirs = true
   $localstatedir   = '/var/lib/jenkins'
@@ -28,8 +32,11 @@ class jenkins::params {
   $_java_args   = '-Djava.awt.headless=true -Djenkins.install.runSetupWizard=false'
   $default_plugins = [
     'credentials', # required by puppet_helper.groovy
+    'mailer', # ssh credentials
+    'display-url-api', # dependency of mailer
   ]
   $purge_plugins = false
+  $jenkins_home = $localstatedir
 
   case $::osfamily {
     'Debian': {
@@ -38,8 +45,9 @@ class jenkins::params {
       $service_provider = undef
       $sysconfdir       = '/etc/default'
       $config_hash_defaults = {
-        'JAVA_ARGS' => { value => $_java_args },
-        'AJP_PORT'  => { value => '-1' },
+        'JAVA_ARGS'    => { value => $_java_args },
+        'AJP_PORT'     => { value => '-1' },
+        'JENKINS_HOME' => { value => $jenkins_home },
       }
     }
     'RedHat': {
@@ -49,6 +57,7 @@ class jenkins::params {
       $config_hash_defaults = {
         'JENKINS_JAVA_OPTIONS' => { value => $_java_args },
         'JENKINS_AJP_PORT'     => { value => '-1' },
+        'JENKINS_HOME'         => { value => $jenkins_home },
       }
 
       # explicitly use systemd if it is available
@@ -73,6 +82,7 @@ class jenkins::params {
       $config_hash_defaults = {
         'JENKINS_JAVA_OPTIONS' => { value => $_java_args },
         'JENKINS_AJP_PORT'     => { value => '-1' },
+        'JENKINS_HOME'         => { value => $jenkins_home },
       }
     }
   }

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -22,6 +22,7 @@ define jenkins::user (
   $full_name = 'Managed by Puppet',
   $public_key = '',
   $ensure = 'present',
+  $bootstrapping = false,
 ){
   validate_re($ensure, '^present$|^absent$')
 

--- a/manifests/users.pp
+++ b/manifests/users.pp
@@ -6,6 +6,28 @@ class jenkins::users {
     fail("Use of private class ${name} by ${caller_module_name}")
   }
 
+  $_bootstrap_users = $::jenkins::bootstrapuser_hash
+
+  if $::jenkins::manage_bootstrapping {
+    if empty($_bootstrap_users) {
+      $_bootstrap_groovy_ensure = absent
+    } else {
+      $_bootstrap_groovy_ensure = present
+    }
+  } else {
+    $_bootstrap_groovy_ensure = absent
+  }
+
+  file { "${::jenkins::jenkins_home}/init.groovy.d/puppet.bootstapping.groovy":
+    ensure    => $_bootstrap_groovy_ensure,
+    owner     => $::jenkins::user,
+    group     => $::jenkins::group,
+    mode      => '0640',
+    tag       => 'jenkins_groovy_init_script',
+    show_diff => false,
+    content   => template('jenkins/home/jenkins/init.groovy.d/puppet.bootstapping.groovy.erb'),
+  }
+
   create_resources('jenkins::user', $::jenkins::user_hash)
 
 }

--- a/templates/home/jenkins/init.groovy.d/puppet.bootstapping.groovy.erb
+++ b/templates/home/jenkins/init.groovy.d/puppet.bootstapping.groovy.erb
@@ -1,0 +1,92 @@
+#!groovy
+/*
+
+  !! Managed by Puppet !!
+  Setup initial bootstrapping user for puppet
+
+*/
+
+import jenkins.model.*
+import hudson.security.*
+import com.cloudbees.plugins.credentials.*
+import hudson.plugins.active_directory.*
+import hudson.security.HudsonPrivateSecurityRealm.Details
+
+// Code
+def instance = Jenkins.getInstance()
+def currentRealm = instance.getSecurityRealm().getClass().getName()
+
+// bootstrap users
+def bootstrapUsers = [
+<% @_bootstrap_users.each do |username,userconfig| -%>
+  [
+    username : '<%= username %>',
+    password : '<%= userconfig['password'] %>',
+    email : '<%= userconfig['email'] %>',
+    full_name : '<%= userconfig['full_name'] %>',
+    ssh_key : '<%= userconfig['public_key'] %>',
+  ],
+<% end -%>
+]
+
+if (currentRealm == 'hudson.security.HudsonPrivateSecurityRealm') {
+  println "--> Jenkins Local Security Realm already configured (HudsonPrivateSecurityRealm)"
+} else {
+  println "--> Configuring Jenkins Local Security Realm (HudsonPrivateSecurityRealm)"
+  def hudsonRealm = new HudsonPrivateSecurityRealm(false)
+  instance.setSecurityRealm(hudsonRealm)
+  println "--> Done configuring Jenkins Local Security Realm"
+}
+
+
+bootstrapUsers.each { user ->
+
+  // User config
+  def username = user['username']
+  def password = user['password']
+  def email = user['email']
+  def full_name = user['full_name']
+  def ssh_key = user['ssh_key']
+
+  println "--> Configuring Jenkins Automation User (${username} with ssh_key ${ssh_key})"
+
+
+  // Get user and create if not exists
+  def userObject = hudson.model.User.get(username,false)
+  if (userObject == null) {
+    println "--> creating new user '${username}'"
+    userObject = instance.getSecurityRealm().createAccount(username,password)
+  } else {
+    println "--> using existing user '${username}'"
+  }
+
+
+  // set full name
+  userObject.setFullName(full_name)
+
+
+  // password
+  userObject.addProperty(Details.fromPlainPassword(password))
+
+  // set email
+  def email_param = this.class.classLoader.loadClass('hudson.tasks.Mailer$UserProperty').newInstance(email)
+  userObject.addProperty(email_param)
+
+
+  // set ssh_key
+  if ( ssh_key != '' ) {
+    def keys_param = new org.jenkinsci.main.modules.cli.auth.ssh.UserPropertyImpl(ssh_key)
+    userObject.addProperty(keys_param)
+  }
+
+  // save the user
+  userObject.save()
+
+
+}
+
+
+
+println "--> Saving Config"
+instance.save()
+println "--> Done Saving Config"

--- a/templates/home/jenkins/init.groovy.d/puppet.sshd.groovy.erb
+++ b/templates/home/jenkins/init.groovy.d/puppet.sshd.groovy.erb
@@ -1,0 +1,24 @@
+#!groovy
+/*
+
+  !! Managed by Puppet !!
+  Setup SSHD (as now disabled by default)
+
+*/
+
+import jenkins.model.*
+
+<% if @_jenkins_sshd_port.to_s != '' -%>
+// manage built in sshd
+// See https://github.com/jenkinsci/sshd-module/blob/master/src/main/java/org/jenkinsci/main/modules/sshd/SSHD.java#L67
+// -1 to disable this, 0 to run with a random port, otherwise the port number.
+def inst = Jenkins.getInstance()
+def sshDesc = inst.getDescriptor("org.jenkinsci.main.modules.sshd.SSHD")
+println "--> Setting SSHD port to <%= @_jenkins_sshd_port %>"
+sshDesc.setPort(<%= @_jenkins_sshd_port %>)
+sshDesc.save()
+
+<% else -%>
+println "--> Not configuring SSHD Port"
+<% end -%>
+


### PR DESCRIPTION
Because we build Jenkins boxes on Deb, there's some issues with the way that we start Jenkins without an automation user already on the box. Jenkins creates it's own user then blocks the API usage that this module relies on.

This PR adds a new thingy that creates the Automation user before Jenkins starts up.