### PR TITLE
Use Sensitive to redact passwords

### DIFF
--- a/manifests/cli.pp
+++ b/manifests/cli.pp
@@ -66,8 +66,9 @@ class jenkins::cli {
   )
 
   # Do a safe restart of Jenkins (only when notified)
+  # The command is marked Sensitive as cmd can contain a password from jenkins::_cli_auth_arg
   exec { 'safe-restart-jenkins':
-    command     => "${cmd} safe-restart && /bin/sleep 10",
+    command     => Sensitive("${cmd} safe-restart && /bin/sleep 10"),
     path        => ['/bin', '/usr/bin'],
     tries       => 10,
     try_sleep   => 2,

--- a/manifests/cli/config.pp
+++ b/manifests/cli/config.pp
@@ -68,7 +68,7 @@ class jenkins::cli::config(
       ensure  => 'file',
       mode    => '0400',
       backup  => false,
-      content => "${cli_username}:${cli_password}",
+      content => Sensitive("${cli_username}:${cli_password}"),
     }
 
     # allow this class to be included when not running as root

--- a/manifests/cli/reload.pp
+++ b/manifests/cli/reload.pp
@@ -9,8 +9,9 @@ class jenkins::cli::reload {
   }
 
   # Reload all Jenkins config from disk (only when notified)
+  # The command is marked Sensitive as jenkins::cli::cmd can contain a password
   exec { 'reload-jenkins':
-    command     => "${::jenkins::cli::cmd} reload-configuration",
+    command     => Sensitive("${::jenkins::cli::cmd} reload-configuration"),
     path        => ['/bin', '/usr/bin'],
     tries       => 10,
     try_sleep   => 2,

--- a/manifests/job/absent.pp
+++ b/manifests/job/absent.pp
@@ -32,9 +32,10 @@ define jenkins::job::absent(
   }
 
   # Delete the job
+  # The command is marked Sensitive as jenkins::cli::cmd can contain a password
   exec { "jenkins delete-job ${jobname}":
     path      => ['/usr/bin', '/usr/sbin', '/bin'],
-    command   => "${jenkins::cli::cmd} delete-job \"${jobname}\"",
+    command   => Sensitive("${jenkins::cli::cmd} delete-job \"${jobname}\""),
     logoutput => false,
     onlyif    => "test -f \"${config_path}\"",
     require   => Exec['jenkins-cli'],

--- a/manifests/job/present.pp
+++ b/manifests/job/present.pp
@@ -85,18 +85,20 @@ define jenkins::job::present(
   }
 
   # Use Jenkins CLI to create the job
+  # The command is marked Sensitive as jenkins_cli can contain a password
   $cat_config = "cat \"${tmp_config_path}\""
   $create_job = "${jenkins_cli} create-job \"${jobname}\""
   exec { "jenkins create-job ${jobname}":
-    command => "${cat_config} | ${create_job}",
+    command => Sensitive("${cat_config} | ${create_job}"),
     creates => [$config_path, "${job_dir}/builds"],
     require => File[$tmp_config_path],
   }
 
   # Use Jenkins CLI to update the job if it already exists
+  # The command is marked Sensitive as jenkins_cli can contain a password
   $update_job = "${jenkins_cli} update-job ${jobname}"
   exec { "jenkins update-job ${jobname}":
-    command => "${cat_config} | ${update_job}",
+    command => Sensitive("${cat_config} | ${update_job}"),
     onlyif  => "test -e ${config_path}",
     unless  => "${difftool} ${config_path} ${tmp_config_path}",
     require => File[$tmp_config_path],

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -35,14 +35,14 @@ define jenkins::user (
     'present': {
       # XXX not idempotent
       jenkins::cli::exec { "create-jenkins-user-${title}":
-        command => [
+        command => Sensitive([
           'create_or_update_user',
           $title,
           $email,
           "'${password}'",
           "'${full_name}'",
           "'${public_key}'",
-        ],
+        ]),
       }
     }
     'absent': {

--- a/manifests/users.pp
+++ b/manifests/users.pp
@@ -18,6 +18,7 @@ class jenkins::users {
     $_bootstrap_groovy_ensure = absent
   }
 
+  # The content parameter is marked Sensitive as the template can contain user passwords
   file { "${::jenkins::jenkins_home}/init.groovy.d/puppet.bootstapping.groovy":
     ensure    => $_bootstrap_groovy_ensure,
     owner     => $::jenkins::user,
@@ -25,7 +26,7 @@ class jenkins::users {
     mode      => '0640',
     tag       => 'jenkins_groovy_init_script',
     show_diff => false,
-    content   => template('jenkins/home/jenkins/init.groovy.d/puppet.bootstapping.groovy.erb'),
+    content   => Sensitive(template('jenkins/home/jenkins/init.groovy.d/puppet.bootstapping.groovy.erb')),
   }
 
   create_resources('jenkins::user', $::jenkins::user_hash)

--- a/spec/classes/cli/config_spec.rb
+++ b/spec/classes/cli/config_spec.rb
@@ -112,6 +112,20 @@ describe 'jenkins::cli::config', :type => :class do
         end # as root
       end # when ssh_private_key is also set
     end # ssh_private_key_content
+
+    context 'cli_username and cli_password' do
+      it_behaves_like 'validate_string', :cli_username
+      it_behaves_like 'validate_string', :cli_password
+
+      let(:params) do
+        {
+          :cli_username => 'abc',
+          :cli_password => '123',
+        }
+      end
+
+      it { should contain_file('/tmp/jenkins_credentials_for_puppet').with_content('abc:123') }
+    end
   end # parameters
 
   describe 'package gem provider' do

--- a/spec/defines/jenkins_cli_exec_spec.rb
+++ b/spec/defines/jenkins_cli_exec_spec.rb
@@ -94,6 +94,45 @@ describe 'jenkins::cli::exec', :type => :define do
         )
       end
     end
+
+    context 'Sensitive(bar)' do
+      let(:params) {{ :command => sensitive('bar') }}
+
+      it do
+        should contain_exec('foo').with(
+          :command   => "#{helper_cmd} bar",
+          :tries     => 10,
+          :try_sleep => 10,
+          :unless    => nil,
+        )
+      end
+    end
+
+    context "Sensitive(['bar'])" do
+      let(:params) {{ :command => sensitive(%w{ bar }) }}
+
+      it do
+        should contain_exec('foo').with(
+          :command   => "#{helper_cmd} bar",
+          :tries     => 10,
+          :try_sleep => 10,
+          :unless    => nil,
+        )
+      end
+    end
+
+    context "Sensitive(['bar', 'baz'])" do
+      let(:params) {{ :command => sensitive(%w{bar baz}) }}
+
+      it do
+        should contain_exec('foo').with(
+          :command   => "#{helper_cmd} bar baz",
+          :tries     => 10,
+          :try_sleep => 10,
+          :unless    => nil,
+        )
+      end
+    end
   end # command =>
 
   describe 'unless =>' do
@@ -110,5 +149,20 @@ describe 'jenkins::cli::exec', :type => :define do
         )
       end
     end
+
+    context 'Sensitive(bar)' do
+      let(:params) {{ :unless => sensitive('bar') }}
+
+      it do
+        should contain_exec('foo').with(
+          :command     => "#{helper_cmd} foo",
+          :environment => [ "HELPER_CMD=eval #{helper_cmd}" ],
+          :unless      => 'bar',
+          :tries       => 10,
+          :try_sleep   => 10,
+        )
+      end
+    end
   end # unless_cli_helper =>
+
 end

--- a/spec/defines/jenkins_credentials_spec.rb
+++ b/spec/defines/jenkins_credentials_spec.rb
@@ -35,7 +35,7 @@ describe 'jenkins::credentials', :type => :define do
     it { should contain_jenkins__cli__exec('create-jenkins-credentials-foo').with({
       :command    => [ 'create_or_update_credentials' , "#{title}", "'mypass'",
                        "''", "'Managed by Puppet'", "''" ],
-      :unless     => "for i in \$(seq 1 10); do \$HELPER_CMD credential_info #{title} && break || sleep 10; done | grep #{title}",
+      :unless     => "for i in \$(seq 1 10); do \$HELPER_CMD credential_info #{title} && break || sleep 10; done | grep #{title} > /dev/null",
     })}
   end
 
@@ -58,7 +58,7 @@ describe 'jenkins::credentials', :type => :define do
     it { should contain_jenkins__cli__exec('create-jenkins-credentials-foo').with({
       :command    => [ 'create_or_update_credentials' , "#{title}", "'mypass'",
                        "'e94d3b98-5ba4-43b9-89ed-79a08ea97f6f'", "'Managed by Puppet'", "''" ],
-      :unless     => "for i in \$(seq 1 10); do \$HELPER_CMD credential_info #{title} && break || sleep 10; done | grep #{title}",
+      :unless     => "for i in \$(seq 1 10); do \$HELPER_CMD credential_info #{title} && break || sleep 10; done | grep #{title} > /dev/null",
     })}
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,8 @@ $LOAD_PATH.unshift(File.expand_path(File.dirname(__FILE__) + '/fixtures/modules/
 
 require 'spec/helpers/rspechelpers'
 
+require 'spec_helper_local' if File.file?(File.join(File.dirname(__FILE__), 'spec_helper_local.rb'))
+
 RSpec.configure do |c|
   # Override puppetlabs_spec_helper's stupid setting of mock_with to :mocha,
   # which is a totally piece of garbage mocking library

--- a/spec/spec_helper_local.rb
+++ b/spec/spec_helper_local.rb
@@ -1,0 +1,5 @@
+# Add our own helper function to produce Sensitive types
+# since puppet-rspec doesn't seem to support this currently
+def sensitive(string)
+  return RSpec::Puppet::RawString.new("Sensitive(#{string})")
+end


### PR DESCRIPTION
As it stands the Jenkins module tends to leak credentials like a sieve when run in debug mode. This PR seeks to handle that by wrapping them in Sensitive wherever possible. I've tried to add spec tests where it makes sense. Unfortunately rspec-puppet doesn't currently handle testing whether or not a parameter is Sensitive.

Many of the leaks are in execs which can potentially pass along a username/password in the command string to authenticate. Marking those Sensitive has the unfortunate side-effect of redacting the whole command but we don't yet have the ability to redact only part of a string.

Also I changed one 'unless' to redirect to /dev/null as it was returning credentials and those were getting logged at debug unconditionally. I've opened a bug about this ([PUP-9956](https://tickets.puppetlabs.com/browse/PUP-9956)).

I know we've got a branch in-development that is using the latest version of the Jenkins module. If we go with that I think most of these changes should be able to be rebased onto the newer version without too much effort.