### PR TITLE
Rework Sensitive in jenkins::cli::exec

### DIFF
--- a/manifests/cli/exec.pp
+++ b/manifests/cli/exec.pp
@@ -4,8 +4,8 @@
 # CLI.
 #
 define jenkins::cli::exec(
-  Variant[String, Sensitive[String], Undef]                   $unless  = undef,
-  Variant[String, Array, Sensitive[String], Sensitive[Array]] $command = $title,
+  Variant[String, Sensitive[String], Undef] $unless  = undef,
+  Variant[String, Array]                    $command = $title,
 ) {
 
   include ::jenkins
@@ -16,29 +16,16 @@ define jenkins::cli::exec(
     -> Jenkins::Cli::Exec[$title]
       -> Anchor['jenkins::end']
 
-  # If we passed in a Sensitive command we need to unwrap it first
-  # Otherwise the join/delete/flatten sequence won't work correctly
-  $unwrapped_command = $command ? {
-    Sensitive => $command.unwrap(),
-    default   => $command,
-  }
-
   # $command may be either a string or an array due to the use of flatten()
-  $unwrapped_run = join(
+  $run = join(
     delete_undef_values(
       flatten([
         $::jenkins::cli_helper::helper_cmd,
-        $unwrapped_command,
+        $command,
       ])
     ),
     ' '
   )
-
-  # If we passed in a Sensitive command we want to make sure to wrap it again before use
-  $run = $command ? {
-    Sensitive => Sensitive($unwrapped_run),
-    default   => $unwrapped_run,
-  }
 
   if $unless {
     $environment_run = [ "HELPER_CMD=eval ${::jenkins::cli_helper::helper_cmd}" ]
@@ -46,9 +33,11 @@ define jenkins::cli::exec(
     $environment_run = undef
   }
 
+  # The command is marked Sensitive as $::jenkins::cli_helper::helper_cmd
+  # may contain a password in plaintext.
   exec { $title:
     provider    => 'shell',
-    command     => $run,
+    command     => Sensitive($run),
     environment => $environment_run,
     unless      => $unless,
     tries       => $::jenkins::cli_tries,

--- a/manifests/credentials.pp
+++ b/manifests/credentials.pp
@@ -34,14 +34,14 @@ define jenkins::credentials (
   case $ensure {
     'present': {
       jenkins::cli::exec { "create-jenkins-credentials-${title}":
-        command => Sensitive([
+        command => [
           'create_or_update_credentials',
           $title,
           "'${password}'",
           "'${uuid}'",
           "'${description}'",
           "'${private_key_or_path}'",
-        ]),
+        ],
         unless  => Sensitive("for i in \$(seq 1 ${::jenkins::cli_tries}); do \$HELPER_CMD credential_info ${title} && break || sleep ${::jenkins::cli_try_sleep}; done | grep ${title} > /dev/null"), # lint:ignore:140chars
       }
       # The above unless redirects to /dev/null to avoid logging in debug (see PUP-9956).

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -35,14 +35,14 @@ define jenkins::user (
     'present': {
       # XXX not idempotent
       jenkins::cli::exec { "create-jenkins-user-${title}":
-        command => Sensitive([
+        command => [
           'create_or_update_user',
           $title,
           $email,
           "'${password}'",
           "'${full_name}'",
           "'${public_key}'",
-        ]),
+        ],
       }
     }
     'absent': {

--- a/spec/defines/jenkins_cli_exec_spec.rb
+++ b/spec/defines/jenkins_cli_exec_spec.rb
@@ -94,45 +94,6 @@ describe 'jenkins::cli::exec', :type => :define do
         )
       end
     end
-
-    context 'Sensitive(bar)' do
-      let(:params) {{ :command => sensitive('bar') }}
-
-      it do
-        should contain_exec('foo').with(
-          :command   => "#{helper_cmd} bar",
-          :tries     => 10,
-          :try_sleep => 10,
-          :unless    => nil,
-        )
-      end
-    end
-
-    context "Sensitive(['bar'])" do
-      let(:params) {{ :command => sensitive(%w{ bar }) }}
-
-      it do
-        should contain_exec('foo').with(
-          :command   => "#{helper_cmd} bar",
-          :tries     => 10,
-          :try_sleep => 10,
-          :unless    => nil,
-        )
-      end
-    end
-
-    context "Sensitive(['bar', 'baz'])" do
-      let(:params) {{ :command => sensitive(%w{bar baz}) }}
-
-      it do
-        should contain_exec('foo').with(
-          :command   => "#{helper_cmd} bar baz",
-          :tries     => 10,
-          :try_sleep => 10,
-          :unless    => nil,
-        )
-      end
-    end
   end # command =>
 
   describe 'unless =>' do


### PR DESCRIPTION
Additional testing after the last PR showed that even the non-Sensitive execs (e.g. deleting users) were leaking credentials in our environment. This is because the helper_cmd used in jenkins::cli::exec has credentials in it -- in effect, all commands invoked by jenkins::cli::exec in our environment should be Sensitive.

This commit backs out some of the changes from the last PR (optionally taking a Sensitive command in jenkins::cli::exec, marking some of those commands as Sensitive) in favor of just marking all commands invoked by jenkins::cli::exec as Sensitive.

I've gone through and tested this against the invocations of jenkins::cli::exec to ensure that they are correctly redacted. 